### PR TITLE
added cli submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "execDAT-CLI"]
+	path = execDAT-CLI
+	url = git@github.com:AustrianDataLAB/execDAT-CLI.git


### PR DESCRIPTION
The code for the CLI can be found in the [execDAT-CLI repo](https://github.com/AustrianDataLAB/execDAT-CLI). This separation allows users to install the CLI without the need to pull the entire source, which includes code for the server.