### PR TITLE
Template for the ADRs

### DIFF
--- a/docs/adrs/YYYY-MM-DD-template.md
+++ b/docs/adrs/YYYY-MM-DD-template.md
@@ -1,0 +1,26 @@
+# Title
+
+Date: YYYY-MM-DD
+
+## Status
+
+What is the status if the ADR?
+
+Possible options:
+* __PROPOSED__
+* __ACCEPTED__
+* __REJECTED__
+* __DEPRECATED__ (include reference to the superseding ADR)
+* __SUPERSEDED__ (include reference to the deprecating ADR)
+
+## Context
+
+What is the context of this ADR? What is the issue that we are seeing? What is motivating this decision or change?
+
+## Decision
+
+What is the change we are proposing? What do we plan on doing to solve the issue?
+
+## Consequences
+
+What are the consequences of the change? What will be more difficult? What will be easier?


### PR DESCRIPTION
We adapted an ADR template we found online. Some changes are unique to our template: We are using the date as prefix in the ADR folder for natural ordering. Also, we require a link to the corresponding ADR in deprecated and superseded ADRs.